### PR TITLE
:bug: Fix incorrect link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Simply download the x86 target with the suggested command and everything should 
 
 ## Repo standards
 
-We use the [Gitmoji commit standards](gitmoji.dev).
+We use the [Gitmoji commit standards](https://gitmoji.dev/).
 
 ## References
 


### PR DESCRIPTION
Link URL was `gitmoji.dev`, but this was interpreted as a local path. Fixed by changing to `https://gitmoji.dev/`.